### PR TITLE
Misc code cleanup

### DIFF
--- a/Barmoji.h
+++ b/Barmoji.h
@@ -9,35 +9,35 @@
 #define kPrefDomain "com.cpdigitaldarkroom.barmoji"
 
 @interface EMFEmojiToken : NSObject
-@property (nonatomic,copy) NSString * string;
+@property (nonatomic, copy) NSString *string;
 @end
 
 @interface EMFEmojiPreferences : NSObject
--(NSArray *)allRecents;
--(NSArray *)recentEmojis;
+- (NSArray *)allRecents;
+- (NSArray *)recentEmojis;
 @end
 
 @class BarmojiCollectionView;
 
 @interface TUIPredictionView : UIView // iOS 13 +
-@property (nonatomic,retain) BarmojiCollectionView* barmoji;
+@property (nonatomic, retain) BarmojiCollectionView *barmoji;
 - (void)toggleBarmoji;
 @end
 
 @interface UIKeyboardImpl : UIView
 
-+(id)activeInstance;
--(void)insertText:(id)arg1 ;
++ (id)activeInstance;
+- (void)insertText:(id)arg1;
 @end
 
 @interface UIKeyboardEmoji
-@property (nonatomic,retain) NSString* emojiString;
-+(id)emojiWithString:(id)arg1 withVariantMask:(unsigned long long)arg2 ;
+@property (nonatomic, retain) NSString *emojiString;
++ (id)emojiWithString:(id)arg1 withVariantMask:(NSUInteger)arg2;
 @end
 
 @interface UIKeyboardEmojiCollectionViewCell : UICollectionViewCell
-@property (nonatomic,copy) UIKeyboardEmoji* emoji;
-@property (assign, nonatomic) long long emojiFontSize;
+@property (nonatomic, copy) UIKeyboardEmoji *emoji;
+@property (assign, nonatomic) NSInteger emojiFontSize;
 @end
 
 @interface UIKeyboardEmojiKeyDisplayController : NSObject
@@ -45,23 +45,23 @@
 @end
 
 @interface UIKeyboardPredictionView : UIView
-@property (nonatomic,retain) BarmojiCollectionView* barmoji;
+@property (nonatomic, retain) BarmojiCollectionView *barmoji;
 @end
 
 @interface UIKeyboardDockItemButton: UIButton
 @end
 
 @interface UIKeyboardDockItem : NSObject
-@property (nonatomic,retain) UIKeyboardDockItemButton * button; 
+@property (nonatomic, retain) UIKeyboardDockItemButton *button; 
 @end
 
 @interface UIKeyboardDockView : UIView
-@property (nonatomic,retain) BarmojiCollectionView* barmoji;
--(id)_keyboardLayoutView;
+@property (nonatomic, retain) BarmojiCollectionView *barmoji;
+- (id)_keyboardLayoutView;
 @end
 
 @interface UISystemKeyboardDockController : UIViewController
-@property (nonatomic,retain) UIKeyboardDockView* dockView;
+@property (nonatomic, retain) UIKeyboardDockView *dockView;
 @end
 
 @interface TIKeyboardCandidateSingle : NSObject

--- a/Barmoji.xm
+++ b/Barmoji.xm
@@ -30,8 +30,8 @@ int barmojiFeedbackType = 7;
 - (instancetype)initWithFrame:(CGRect)frame {
 	TUIPredictionView *predictionView = %orig;
 
-	if(predictionView) {
-		if(barmojiEnabled && barmojiPredictiveEnabled) {
+	if (predictionView) {
+		if (barmojiEnabled && barmojiPredictiveEnabled) {
 
 			self.barmoji = [[BarmojiCollectionView alloc] initForPredictiveBar:YES];
 			self.barmoji.feedbackType = barmojiFeedbackType;
@@ -52,8 +52,8 @@ int barmojiFeedbackType = 7;
 }
 
 - (void)addSubview:(UIView *)subview {
-	if(barmojiEnabled && barmojiPredictiveEnabled) {
-		if(![subview isKindOfClass:[BarmojiCollectionView class]]) {
+	if (barmojiEnabled && barmojiPredictiveEnabled) {
+		if (![subview isKindOfClass:[BarmojiCollectionView class]]) {
 			subview.hidden = YES;
 		}
 	}
@@ -66,9 +66,9 @@ int barmojiFeedbackType = 7;
 	[[NSNotificationCenter defaultCenter] postNotificationName:@"TryReloadTest" object:nil];
 }
 
--(void)_didRecognizeTapGesture:(id)arg1 {
-	if(barmojiEnabled) {
-		if(barmojiPredictiveEnabled && showingBarmoji) {
+- (void)_didRecognizeTapGesture:(id)arg1 {
+	if (barmojiEnabled) {
+		if (barmojiPredictiveEnabled && showingBarmoji) {
 			return;
 		}
 	}
@@ -119,8 +119,8 @@ int barmojiFeedbackType = 7;
 - (instancetype)initWithFrame:(CGRect)frame {
 	UIKeyboardPredictionView *predictionView = %orig;
 
-	if(predictionView) {
-		if(barmojiEnabled && barmojiPredictiveEnabled) {
+	if (predictionView) {
+		if (barmojiEnabled && barmojiPredictiveEnabled) {
 
 			self.barmoji = [[BarmojiCollectionView alloc] initForPredictiveBar:YES];
 			self.barmoji.feedbackType = barmojiFeedbackType;
@@ -141,17 +141,17 @@ int barmojiFeedbackType = 7;
 }
 
 - (void)addSubview:(UIView *)subview {
-	if(barmojiEnabled && barmojiPredictiveEnabled) {
-		if(![subview isKindOfClass:[BarmojiCollectionView class]]) {
+	if (barmojiEnabled && barmojiPredictiveEnabled) {
+		if (![subview isKindOfClass:[BarmojiCollectionView class]]) {
 			subview.hidden = YES;
 		}
 	}
 	%orig;
 }
 
--(void)activateCandidateAtPoint:(CGPoint)arg1  {
-	if(barmojiEnabled) {
-		if(barmojiPredictiveEnabled && showingBarmoji) {
+- (void)activateCandidateAtPoint:(CGPoint)arg1  {
+	if (barmojiEnabled) {
+		if (barmojiPredictiveEnabled && showingBarmoji) {
 			return;
 		}
 	}
@@ -183,9 +183,9 @@ int barmojiFeedbackType = 7;
 
 - (instancetype)initWithFrame:(CGRect)frame {
 	UIKeyboardDockView *dockView = %orig;
-	if(dockView) {
+	if (dockView) {
 
-		if(barmojiEnabled && barmojiBottomEnabled) {
+		if (barmojiEnabled && barmojiBottomEnabled) {
 			self.barmoji = [[BarmojiCollectionView alloc] initForPredictiveBar:NO];
 			self.barmoji.feedbackType = barmojiFeedbackType;
 			self.barmoji.translatesAutoresizingMaskIntoConstraints = NO;
@@ -200,12 +200,12 @@ int barmojiFeedbackType = 7;
 	return dockView;
 }
 
--(void)setLeftDockItem:(UIKeyboardDockItem *)arg1 {
-	if(barmojiBottomFullWidth) { return ;}
+- (void)setLeftDockItem:(UIKeyboardDockItem *)arg1 {
+	if (barmojiBottomFullWidth) { return;}
 	%orig;
 }
--(void)setRightDockItem:(UIKeyboardDockItem *)arg1 {
-	if(barmojiBottomFullWidth) { return ;}
+- (void)setRightDockItem:(UIKeyboardDockItem *)arg1 {
+	if (barmojiBottomFullWidth) { return;}
 	%orig;
 }
 
@@ -229,7 +229,7 @@ static void loadPrefs() {
 
 static void updateSettings(CFNotificationCenterRef center, void *observer, CFStringRef name, const void *object, CFDictionaryRef userInfo) {
 
-	NSDictionary *info = (__bridge NSDictionary*)userInfo;
+	NSDictionary *info = (__bridge NSDictionary *)userInfo;
 
 	barmojiBottomEnabled = [info[@"bottom"] boolValue];
 	barmojiBottomFullWidth = [info[@"fullwidth"] boolValue];
@@ -259,12 +259,10 @@ static void updateSettings(CFNotificationCenterRef center, void *observer, CFStr
 				BOOL isApplication = [executablePath rangeOfString:@"/Application"].location != NSNotFound;
 				
 				if (isSpringBoard || isApplication) {
-
 					loadPrefs();
 
 					if (@available(iOS 13, *)) {
-						
-						NSBundle* bundle = [NSBundle bundleWithPath:@"/System/Library/PrivateFrameworks/TextInputUI.framework"];
+						NSBundle *bundle = [NSBundle bundleWithPath:@"/System/Library/PrivateFrameworks/TextInputUI.framework"];
 						if (!bundle.loaded) [bundle load];
 
 						%init(thirteenPlus)

--- a/BarmojiCollectionView.m
+++ b/BarmojiCollectionView.m
@@ -38,7 +38,7 @@
     _replacingPredictiveBar = forPredictive;
     _useCustomEmojis = (emojiSource == 2);
 
-    if(_useCustomEmojis) {
+    if (_useCustomEmojis) {
         NSString *emojiString = ([prefs objectForKey:@"CustomEmojis"] ? [prefs objectForKey:@"CustomEmojis"] : @"");
 
         NSMutableArray *emojis = [NSMutableArray new]; 
@@ -60,7 +60,8 @@
     flowLayout.minimumInteritemSpacing = 0;
     flowLayout.minimumLineSpacing = 0;
 
-    if(self = [super initWithFrame:CGRectZero collectionViewLayout:flowLayout]) {
+    self = [super initWithFrame:CGRectZero collectionViewLayout:flowLayout];
+    if (self) {
         self.backgroundColor = [UIColor clearColor];
         self.delegate = self;
         self.dataSource = self;
@@ -105,7 +106,7 @@
 
 - (UICollectionViewCell *)collectionView:(UICollectionView *)collectionView cellForItemAtIndexPath:(NSIndexPath *)indexPath {
     BarmojiEmojiCell *cell = [collectionView dequeueReusableCellWithReuseIdentifier:@"kEmojiCellIdentifier" forIndexPath:indexPath];
-    if(_useCustomEmojis) {
+    if (_useCustomEmojis) {
         NSString *emojiString = self.customEmojis[indexPath.row];
         cell.emoji = [UIKeyboardEmoji emojiWithString:emojiString withVariantMask:0];
     } else {
@@ -115,8 +116,7 @@
 }
 
 - (NSInteger)collectionView:(UICollectionView *)collectionView numberOfItemsInSection:(NSInteger)section {
-    int count =  _useCustomEmojis ? self.customEmojis.count : _recentEmojis.count;
-    return count;
+    return _useCustomEmojis ? self.customEmojis.count : _recentEmojis.count;
 }
 
 - (CGSize)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout *)collectionViewLayout sizeForItemAtIndexPath:(NSIndexPath *)indexPath {
@@ -124,7 +124,7 @@
     return CGSizeMake(useableWidth, 34);
 }
 
-- (UIEdgeInsets)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout*)collectionViewLayout insetForSectionAtIndex:(NSInteger)section {
+- (UIEdgeInsets)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout *)collectionViewLayout insetForSectionAtIndex:(NSInteger)section {
     if (self.replacingPredictiveBar || self.fullWidth) {
         return UIEdgeInsetsZero;
     }
@@ -134,12 +134,12 @@
 
 - (void)collectionView:(UICollectionView *)collectionView didSelectItemAtIndexPath:(NSIndexPath *)indexPath {
 
-    if(self.feedbackType != 7) {
+    if (self.feedbackType != 7) {
         [[BarmojiHapticsManager sharedManager] actuateHapticsForType:self.feedbackType];
     }
     
     UIKeyboardEmoji *pressedEmoji;
-    if(_useCustomEmojis) {
+    if (_useCustomEmojis) {
         NSString *emojiString = self.customEmojis[indexPath.row];
         pressedEmoji = [UIKeyboardEmoji emojiWithString:emojiString withVariantMask:0];
     } else {
@@ -150,5 +150,3 @@
 }
 
 @end
-
-

--- a/BarmojiEmojiCell.h
+++ b/BarmojiEmojiCell.h
@@ -7,8 +7,9 @@
 //
 
 @class UIKeyboardEmoji;
-@interface BarmojiEmojiCell: UICollectionViewCell
 
-@property (nonatomic,copy) UIKeyboardEmoji *emoji; 
+@interface BarmojiEmojiCell : UICollectionViewCell
+
+@property (nonatomic, copy) UIKeyboardEmoji *emoji; 
 
 @end

--- a/BarmojiEmojiCell.m
+++ b/BarmojiEmojiCell.m
@@ -18,7 +18,8 @@
 @implementation BarmojiEmojiCell
 
 - (instancetype)initWithFrame:(CGRect)frame {
-    if(self = [super initWithFrame:frame]) {
+    self = [super initWithFrame:frame];
+    if (self) {
 
         self.contentView.backgroundColor = [UIColor clearColor];
         self.backgroundColor = [UIColor clearColor];

--- a/BarmojiHapticsManager.m
+++ b/BarmojiHapticsManager.m
@@ -26,19 +26,19 @@
 }
 
 - (void)actuateHapticsForType:(int)feedbackType {
-
-    if (feedbackType == 1) {
-        [self handleHapticFeedbackForSelection];
-    } else if (feedbackType == 2) {
-        [self handleHapticFeedbackForImpactStyle:UIImpactFeedbackStyleLight];
-    } else if (feedbackType == 3) {
-        [self handleHapticFeedbackForImpactStyle:UIImpactFeedbackStyleMedium];
-    } else if (feedbackType == 4) {
-        [self handleHapticFeedbackForImpactStyle:UIImpactFeedbackStyleHeavy];
-    } else if (feedbackType == 5) {
-        [self handleHapticFeedbackForSuccess];
-    } else if (feedbackType == 6) {
-        [self handleHapticFeedbackForWarning];
+    switch (feedbackType) {
+        case 1:
+            [self handleHapticFeedbackForSelection]; break;
+        case 2:
+            [self handleHapticFeedbackForImpactStyle:UIImpactFeedbackStyleLight]; break;
+        case 3:
+            [self handleHapticFeedbackForImpactStyle:UIImpactFeedbackStyleMedium]; break;
+        case 4:
+            [self handleHapticFeedbackForImpactStyle:UIImpactFeedbackStyleHeavy]; break;
+        case 5:
+            [self handleHapticFeedbackForSuccess]; break;
+        case 6:
+            [self handleHapticFeedbackForWarning]; break;
     }
 }
 

--- a/BarmojiHapticsManager.m
+++ b/BarmojiHapticsManager.m
@@ -43,58 +43,58 @@
 }
 
 - (void)handleHapticFeedbackForImpactStyle:(UIImpactFeedbackStyle)style {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        if (@available(iOS 10.0, *)) {
+    if (@available(iOS 10.0, *)) {
+        dispatch_async(dispatch_get_main_queue(), ^{
             _hapticFeedbackGenerator = [[UIImpactFeedbackGenerator alloc] initWithStyle:style];
             [_hapticFeedbackGenerator prepare];
             [_hapticFeedbackGenerator impactOccurred];
             _hapticFeedbackGenerator = nil;
-        }
-    });
+        });
+    }
 }
 
 - (void)handleHapticFeedbackForError {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        if (@available(iOS 10.0, *)) {
+    if (@available(iOS 10.0, *)) {
+        dispatch_async(dispatch_get_main_queue(), ^{
             _hapticFeedbackGenerator = [[UINotificationFeedbackGenerator alloc] init];
             [_hapticFeedbackGenerator prepare];
             [_hapticFeedbackGenerator notificationOccurred:UINotificationFeedbackTypeError];
             _hapticFeedbackGenerator = nil;
-        }
-    });
+        });
+    }
 }
 
 - (void)handleHapticFeedbackForSelection {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        if (@available(iOS 10.0, *)) {
+    if (@available(iOS 10.0, *)) {
+        dispatch_async(dispatch_get_main_queue(), ^{
             _hapticFeedbackGenerator = [[UISelectionFeedbackGenerator alloc] init];
             [_hapticFeedbackGenerator prepare];
             [_hapticFeedbackGenerator selectionChanged];
             _hapticFeedbackGenerator = nil;
-        }
-    });
+        });
+    }
 }
 
 - (void)handleHapticFeedbackForSuccess {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        if (@available(iOS 10.0, *)) {
+    if (@available(iOS 10.0, *)) {
+        dispatch_async(dispatch_get_main_queue(), ^{
             _hapticFeedbackGenerator = [[UINotificationFeedbackGenerator alloc] init];
             [_hapticFeedbackGenerator prepare];
             [_hapticFeedbackGenerator notificationOccurred:UINotificationFeedbackTypeSuccess];
             _hapticFeedbackGenerator = nil;
-        }
-    });
+        });
+    }
 }
 
 - (void)handleHapticFeedbackForWarning {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        if (@available(iOS 10.0, *)) {
+    if (@available(iOS 10.0, *)) {
+        dispatch_async(dispatch_get_main_queue(), ^{
             _hapticFeedbackGenerator = [[UINotificationFeedbackGenerator alloc] init];
             [_hapticFeedbackGenerator prepare];
             [_hapticFeedbackGenerator notificationOccurred:UINotificationFeedbackTypeWarning];
             _hapticFeedbackGenerator = nil;
-        }
-    });
+        });
+    }
 }
 
 @end

--- a/BarmojiHapticsManager.m
+++ b/BarmojiHapticsManager.m
@@ -25,25 +25,19 @@
     return sharedManager;
 }
 
-- (instancetype)init {
-    if(self = [super init]) {
-    }
-    return self;
-}
-
 - (void)actuateHapticsForType:(int)feedbackType {
 
-    if(feedbackType == 1) {
+    if (feedbackType == 1) {
         [self handleHapticFeedbackForSelection];
-    } else if(feedbackType == 2) {
+    } else if (feedbackType == 2) {
         [self handleHapticFeedbackForImpactStyle:UIImpactFeedbackStyleLight];
-    } else if(feedbackType == 3) {
+    } else if (feedbackType == 3) {
         [self handleHapticFeedbackForImpactStyle:UIImpactFeedbackStyleMedium];
-    } else if(feedbackType == 4) {
+    } else if (feedbackType == 4) {
         [self handleHapticFeedbackForImpactStyle:UIImpactFeedbackStyleHeavy];
-    } else if(feedbackType == 5) {
+    } else if (feedbackType == 5) {
         [self handleHapticFeedbackForSuccess];
-    } else if(feedbackType == 6) {
+    } else if (feedbackType == 6) {
         [self handleHapticFeedbackForWarning];
     }
 }

--- a/barmoji/BarmojiEditableTextCell.h
+++ b/barmoji/BarmojiEditableTextCell.h
@@ -1,3 +1,11 @@
+//
+//  BarmojiEditableTextCell.h
+//  barmoji
+//  
+//  Created by Juan Carlos Perez <carlos@jcarlosperez.me> 05/07/2019
+//  © CP Digital Darkroom <admin@cpdigitaldarkroom.com> All rights reserved.
+//
+
 #import <Preferences/PSEditableTableCell.h>
 
 @interface BarmojiEditableTextCell : PSEditableTableCell <UITextViewDelegate, UITextFieldDelegate>

--- a/barmoji/BarmojiEditableTextCell.m
+++ b/barmoji/BarmojiEditableTextCell.m
@@ -4,7 +4,9 @@
 @implementation BarmojiEditableTextCell
 - (id)initWithStyle:(UITableViewCellStyle)arg1 reuseIdentifier:(id)arg2 specifier:(id)arg3 {
 	self = [super initWithStyle:arg1 reuseIdentifier:arg2 specifier:arg3];
-	[self textField].returnKeyType = UIReturnKeyDone;
+	if (self) {
+        [self textField].returnKeyType = UIReturnKeyDone;
+    }
 	return self;
 }
 
@@ -13,20 +15,15 @@
 }
 
 - (BOOL)textField:(UITextField *)textField shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString *)string {
-
-	if ([string length] > 0) {
-		if ([self isEmoji:string]) {
-			return YES;
-		} else {
-			return NO;
-		}
+	if (string.length > 0) {
+		return [self isEmoji:string];
 	}
+
 	return YES;
 }
 
 - (BOOL)isEmoji:(NSString *)character {
-
-    UILabel *characterRender = [[UILabel alloc] initWithFrame:CGRectMake(0, 0, 1, 1)];
+    UILabel *characterRender = [[UILabel alloc] initWithFrame:CGRectZero];
     characterRender.text = character;
     characterRender.backgroundColor = [UIColor blackColor];//needed to remove subpixel rendering colors
     [characterRender sizeToFit];

--- a/barmoji/BarmojiEditableTextCell.m
+++ b/barmoji/BarmojiEditableTextCell.m
@@ -1,3 +1,11 @@
+//
+//  BarmojiEditableTextCell.m
+//  barmoji
+//  
+//  Created by Juan Carlos Perez <carlos@jcarlosperez.me> 05/07/2019
+//  © CP Digital Darkroom <admin@cpdigitaldarkroom.com> All rights reserved.
+//
+
 #import "BarmojiEditableTextCell.h"
 #import "BarmojiPreferences.h"
 
@@ -81,7 +89,6 @@
     }
 
     return colorPixelFound;
-
 }
 
 @end

--- a/barmoji/BarmojiEditableTextCell.m
+++ b/barmoji/BarmojiEditableTextCell.m
@@ -14,7 +14,7 @@
 
 - (BOOL)textField:(UITextField *)textField shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString *)string {
 
-	if([string length] > 0) {
+	if ([string length] > 0) {
 		if ([self isEmoji:string]) {
 			return YES;
 		} else {
@@ -32,7 +32,7 @@
     [characterRender sizeToFit];
 
     CGRect rect = [characterRender bounds];
-    UIGraphicsBeginImageContextWithOptions(rect.size,YES,0.0f);
+    UIGraphicsBeginImageContextWithOptions(rect.size, YES, 0.0f);
     CGContextRef contextSnap = UIGraphicsGetCurrentContext();
     [characterRender.layer renderInContext:contextSnap];
     UIImage *capturedImage = UIGraphicsGetImageFromCurrentImageContext();
@@ -42,9 +42,9 @@
     NSUInteger width = CGImageGetWidth(imageRef);
     NSUInteger height = CGImageGetHeight(imageRef);
     CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
-    unsigned char *rawData = (unsigned char*) calloc(height * width * 4, sizeof(unsigned char));
+    unsigned char *rawData = (unsigned char *) calloc(height * width * 4, sizeof(unsigned char));
     NSUInteger bytesPerPixel = 4;
-    NSUInteger bytesPerRow = bytesPerPixel * width;
+    NSUInteger bytesPerRow = bytesPerPixel *width;
     NSUInteger bitsPerComponent = 8;
     CGContextRef context = CGBitmapContextCreate(rawData, width, height,
                                                  bitsPerComponent, bytesPerRow, colorSpace,

--- a/barmoji/BarmojiRootListController.mm
+++ b/barmoji/BarmojiRootListController.mm
@@ -12,15 +12,14 @@
 extern "C" CFNotificationCenterRef CFNotificationCenterGetDistributedCenter(void);
 
 @interface BarmojiRootListController : PSListController <MFMailComposeViewControllerDelegate>
-
 @property (strong, nonatomic) NSMutableArray *dynamicSpecs;
-
 @end
 
 @implementation BarmojiRootListController
 
 - (instancetype)init {
-  if(self = [super init]) {
+  self = [super init];
+    if (self) {
     [self createDynamicSpecs];
   }
   return self;
@@ -42,8 +41,8 @@ extern "C" CFNotificationCenterRef CFNotificationCenterGetDistributedCenter(void
   [_dynamicSpecs addObject:specifier];
 }
 
--(id)specifiers {
-  if(_specifiers == nil) {
+- (id)specifiers {
+  if (_specifiers == nil) {
 
     NSMutableArray *mutableSpecifiers = [NSMutableArray new];
     PSSpecifier *specifier;
@@ -67,7 +66,7 @@ extern "C" CFNotificationCenterRef CFNotificationCenterGetDistributedCenter(void
 		[mutableSpecifiers addObject:specifier];
 
     int sourceType = [(id)CFBridgingRelease(CFPreferencesCopyAppValue(CFSTR("EmojiSource"), CFSTR("com.cpdigitaldarkroom.barmoji"))) intValue];
-    if(sourceType == 2) {
+    if (sourceType == 2) {
       for(PSSpecifier *sp in _dynamicSpecs) {
         [mutableSpecifiers addObject:sp];
       }
@@ -213,18 +212,18 @@ extern "C" CFNotificationCenterRef CFNotificationCenterGetDistributedCenter(void
 
 }
 
-- (void)mailComposeController:(MFMailComposeViewController*)controller didFinishWithResult:(MFMailComposeResult)result error:(NSError*)error {
+- (void)mailComposeController:(MFMailComposeViewController *)controller didFinishWithResult:(MFMailComposeResult)result error:(NSError *)error {
   [self dismissViewControllerAnimated: YES completion: nil];
 }
 
--(void)setPreferenceValue:(id)value specifier:(PSSpecifier*)specifier {
+- (void)setPreferenceValue:(id)value specifier:(PSSpecifier *)specifier {
   
   [super setPreferenceValue:value specifier:specifier];
 
   NSDictionary *properties = specifier.properties;
   NSString *key = properties[@"key"];
 
-  if([key isEqualToString:@"EmojiSource"]) {
+  if ([key isEqualToString:@"EmojiSource"]) {
     BOOL shouldShow = [value intValue] == 2;
     [self shouldShowCustomEmojiSpecifiers:shouldShow];
   }
@@ -249,7 +248,7 @@ extern "C" CFNotificationCenterRef CFNotificationCenterGetDistributedCenter(void
 }
 
 - (void)shouldShowCustomEmojiSpecifiers:(BOOL)show {
-  if(show) {
+  if (show) {
     [self insertContiguousSpecifiers:_dynamicSpecs afterSpecifierID:@"EmojiSource" animated:YES];
   } else {
     [self removeContiguousSpecifiers:_dynamicSpecs animated:YES];
@@ -259,8 +258,8 @@ extern "C" CFNotificationCenterRef CFNotificationCenterGetDistributedCenter(void
 - (void)respring {
   pid_t pid;
   int status;
-  const char* args[] = {"killall", "-9", "backboardd", NULL};
-  posix_spawn(&pid, "/usr/bin/killall", NULL, NULL, (char* const*)args, NULL);
+  const char *args[] = {"killall", "-9", "backboardd", NULL};
+  posix_spawn(&pid, "/usr/bin/killall", NULL, NULL, (char * const *)args, NULL);
   waitpid(pid, &status, WEXITED);
 }
 

--- a/barmoji/BarmojiRootListController.mm
+++ b/barmoji/BarmojiRootListController.mm
@@ -18,249 +18,249 @@ extern "C" CFNotificationCenterRef CFNotificationCenterGetDistributedCenter(void
 @implementation BarmojiRootListController
 
 - (instancetype)init {
-  self = [super init];
-    if (self) {
-    [self createDynamicSpecs];
-  }
-  return self;
+    self = [super init];
+        if (self) {
+        [self createDynamicSpecs];
+    }
+    return self;
 }
 
 - (void)createDynamicSpecs {
-  PSSpecifier *specifier;
-  _dynamicSpecs = [NSMutableArray new];
+    PSSpecifier *specifier;
+    _dynamicSpecs = [NSMutableArray new];
 
-  specifier = groupSpecifier(@"");
-  [_dynamicSpecs addObject:specifier];
+    specifier = groupSpecifier(@"");
+    [_dynamicSpecs addObject:specifier];
 
-  specifier = textEditCellWithName(@"Emojis:");
-  setClassForSpec(NSClassFromString(@"BarmojiEditableTextCell"));
-  [specifier setProperty:@"com.cpdigitaldarkroom.barmoji" forKey:@"defaults"];
-  setDefaultForSpec(@"");
-  setPlaceholderForSpec(@"Your Favorite Emojis");
-  setKeyForSpec(@"CustomEmojis");
-  [_dynamicSpecs addObject:specifier];
+    specifier = textEditCellWithName(@"Emojis:");
+    setClassForSpec(NSClassFromString(@"BarmojiEditableTextCell"));
+    [specifier setProperty:@"com.cpdigitaldarkroom.barmoji" forKey:@"defaults"];
+    setDefaultForSpec(@"");
+    setPlaceholderForSpec(@"Your Favorite Emojis");
+    setKeyForSpec(@"CustomEmojis");
+    [_dynamicSpecs addObject:specifier];
 }
 
 - (id)specifiers {
-  if (_specifiers == nil) {
+    if (_specifiers == nil) {
 
-    NSMutableArray *mutableSpecifiers = [NSMutableArray new];
-    PSSpecifier *specifier;
+        NSMutableArray *mutableSpecifiers = [NSMutableArray new];
+        PSSpecifier *specifier;
 
-    specifier = groupSpecifier(@"");
-    [mutableSpecifiers addObject:specifier];
+        specifier = groupSpecifier(@"");
+        [mutableSpecifiers addObject:specifier];
 
-    specifier = subtitleSwitchCellWithName(@"Enabled");
-    [specifier setProperty:@"com.cpdigitaldarkroom.barmoji" forKey:@"defaults"];
-    setKeyForSpec(@"BarmojiEnabled");
-    [mutableSpecifiers addObject:specifier];
+        specifier = subtitleSwitchCellWithName(@"Enabled");
+        [specifier setProperty:@"com.cpdigitaldarkroom.barmoji" forKey:@"defaults"];
+        setKeyForSpec(@"BarmojiEnabled");
+        [mutableSpecifiers addObject:specifier];
 
-    specifier = groupSpecifier(@"Shown Emojis");
-    [mutableSpecifiers addObject:specifier];
+        specifier = groupSpecifier(@"Shown Emojis");
+        [mutableSpecifiers addObject:specifier];
 
-    specifier = segmentCellWithName(@"Shown Emojis");
-    [specifier setProperty:@"com.cpdigitaldarkroom.barmoji" forKey:@"defaults"];
-    [specifier setValues:@[@(1), @(2)] titles:@[@"Recent", @"Custom"]];
-    setDefaultForSpec(@1);
-		setKeyForSpec(@"EmojiSource");
-		[mutableSpecifiers addObject:specifier];
+        specifier = segmentCellWithName(@"Shown Emojis");
+        [specifier setProperty:@"com.cpdigitaldarkroom.barmoji" forKey:@"defaults"];
+        [specifier setValues:@[@(1), @(2)] titles:@[@"Recent", @"Custom"]];
+        setDefaultForSpec(@1);
+        setKeyForSpec(@"EmojiSource");
+        [mutableSpecifiers addObject:specifier];
 
-    int sourceType = [(id)CFBridgingRelease(CFPreferencesCopyAppValue(CFSTR("EmojiSource"), CFSTR("com.cpdigitaldarkroom.barmoji"))) intValue];
-    if (sourceType == 2) {
-      for(PSSpecifier *sp in _dynamicSpecs) {
-        [mutableSpecifiers addObject:sp];
-      }
+        int sourceType = [(id)CFBridgingRelease(CFPreferencesCopyAppValue(CFSTR("EmojiSource"), CFSTR("com.cpdigitaldarkroom.barmoji"))) intValue];
+        if (sourceType == 2) {
+            for(PSSpecifier *sp in _dynamicSpecs) {
+                [mutableSpecifiers addObject:sp];
+            }
+        }
+
+        specifier = groupSpecifier(@"Bottom Bar");
+        setFooterForSpec(@"The default Barmoji implementation for iPhone X or devices who have enabled the iPhone X layout.");
+        [mutableSpecifiers addObject:specifier];
+
+        specifier = subtitleSwitchCellWithName(@"Enabled");
+        [specifier setProperty:@"com.cpdigitaldarkroom.barmoji" forKey:@"defaults"];
+        setKeyForSpec(@"BarmojiBottomEnabled");
+        [mutableSpecifiers addObject:specifier];
+
+        specifier = subtitleSwitchCellWithName(@"Full Width");
+        [specifier setProperty:@"com.cpdigitaldarkroom.barmoji" forKey:@"defaults"];
+        setKeyForSpec(@"BarmojiFullWidthBottom");
+        [mutableSpecifiers addObject:specifier];
+
+        specifier = groupSpecifier(@"Predictive Bar");
+        setFooterForSpec(@"Replaces the text prediction bar with Barmoji, useful for non-iPhone X devices");
+        [mutableSpecifiers addObject:specifier];
+
+        specifier = subtitleSwitchCellWithName(@"Enabled");
+        [specifier setProperty:@"com.cpdigitaldarkroom.barmoji" forKey:@"defaults"];
+        setKeyForSpec(@"BarmojiPredictiveEnabled");
+        [mutableSpecifiers addObject:specifier];
+
+        specifier = groupSpecifier(@"Haptic Feedback");
+        [mutableSpecifiers addObject:specifier];
+
+        specifier = [PSSpecifier preferenceSpecifierNamed:@"Feedback Type" target:self set:@selector(setPreferenceValue:specifier:) get:@selector(readPreferenceValue:) detail:NSClassFromString(@"BarmojiListItemsController") cell:PSLinkListCell edit:nil];
+        [specifier setProperty:@"com.cpdigitaldarkroom.barmoji" forKey:@"defaults"];
+        setKeyForSpec(@"BarmojiFeedbackType");
+        [specifier setValues:[self activationTypeValues] titles:[self activationTypeTitles] shortTitles:[self activationTypeShortTitles]];
+        [mutableSpecifiers addObject:specifier];
+
+        specifier = groupSpecifier(@"Layout");
+        setFooterForSpec(@"Scroll direction only applies to the Predictive Bar location.");
+        [mutableSpecifiers addObject:specifier];
+
+        specifier = [PSSpecifier preferenceSpecifierNamed:@"Scroll Direction" target:self set:@selector(setPreferenceValue:specifier:) get:@selector(readPreferenceValue:) detail:NSClassFromString(@"BarmojiListItemsController") cell:PSLinkListCell edit:nil];
+        [specifier setProperty:@"com.cpdigitaldarkroom.barmoji" forKey:@"defaults"];
+        setKeyForSpec(@"BarmojiScrollDirection");
+        [specifier setValues:[self scrollDirectionValues] titles:[self scrollDirectionTitles] shortTitles:[self scrollDirectionShortTitles]];
+        [mutableSpecifiers addObject:specifier];
+
+        specifier = groupSpecifier(@"");
+        setFooterForSpec(@"A respring is required to fully apply setting changes");
+        [mutableSpecifiers addObject:specifier];
+
+        specifier = buttonCellWithName(@"Respring");
+        specifier->action = @selector(respring);
+        [mutableSpecifiers addObject:specifier];
+
+        specifier = groupSpecifier(@"Support");
+        setFooterForSpec(@"Having Trouble? Get in touch and I'll help when I can");
+        [mutableSpecifiers addObject:specifier];
+
+        specifier = buttonCellWithName(@"Email Support");
+        specifier->action = @selector(presentSupportMailController:);
+        [mutableSpecifiers addObject:specifier];
+
+        _specifiers = [mutableSpecifiers copy];
     }
 
-    specifier = groupSpecifier(@"Bottom Bar");
-    setFooterForSpec(@"The default Barmoji implementation for iPhone X or devices who have enabled the iPhone X layout.");
-    [mutableSpecifiers addObject:specifier];
-
-    specifier = subtitleSwitchCellWithName(@"Enabled");
-    [specifier setProperty:@"com.cpdigitaldarkroom.barmoji" forKey:@"defaults"];
-    setKeyForSpec(@"BarmojiBottomEnabled");
-    [mutableSpecifiers addObject:specifier];
-
-    specifier = subtitleSwitchCellWithName(@"Full Width");
-    [specifier setProperty:@"com.cpdigitaldarkroom.barmoji" forKey:@"defaults"];
-    setKeyForSpec(@"BarmojiFullWidthBottom");
-    [mutableSpecifiers addObject:specifier];
-
-    specifier = groupSpecifier(@"Predictive Bar");
-    setFooterForSpec(@"Replaces the text prediction bar with Barmoji, useful for non-iPhone X devices");
-    [mutableSpecifiers addObject:specifier];
-
-    specifier = subtitleSwitchCellWithName(@"Enabled");
-    [specifier setProperty:@"com.cpdigitaldarkroom.barmoji" forKey:@"defaults"];
-    setKeyForSpec(@"BarmojiPredictiveEnabled");
-    [mutableSpecifiers addObject:specifier];
-
-    specifier = groupSpecifier(@"Haptic Feedback");
-    [mutableSpecifiers addObject:specifier];
-
-    specifier = [PSSpecifier preferenceSpecifierNamed:@"Feedback Type" target:self set:@selector(setPreferenceValue:specifier:) get:@selector(readPreferenceValue:) detail:NSClassFromString(@"BarmojiListItemsController") cell:PSLinkListCell edit:nil];
-    [specifier setProperty:@"com.cpdigitaldarkroom.barmoji" forKey:@"defaults"];
-    setKeyForSpec(@"BarmojiFeedbackType");
-    [specifier setValues:[self activationTypeValues] titles:[self activationTypeTitles] shortTitles:[self activationTypeShortTitles]];
-    [mutableSpecifiers addObject:specifier];
-
-    specifier = groupSpecifier(@"Layout");
-    setFooterForSpec(@"Scroll direction only applies to the Predictive Bar location.");
-    [mutableSpecifiers addObject:specifier];
-
-    specifier = [PSSpecifier preferenceSpecifierNamed:@"Scroll Direction" target:self set:@selector(setPreferenceValue:specifier:) get:@selector(readPreferenceValue:) detail:NSClassFromString(@"BarmojiListItemsController") cell:PSLinkListCell edit:nil];
-    [specifier setProperty:@"com.cpdigitaldarkroom.barmoji" forKey:@"defaults"];
-    setKeyForSpec(@"BarmojiScrollDirection");
-    [specifier setValues:[self scrollDirectionValues] titles:[self scrollDirectionTitles] shortTitles:[self scrollDirectionShortTitles]];
-    [mutableSpecifiers addObject:specifier];
-
-    specifier = groupSpecifier(@"");
-    setFooterForSpec(@"A respring is required to fully apply setting changes");
-    [mutableSpecifiers addObject:specifier];
-
-    specifier = buttonCellWithName(@"Respring");
-    specifier->action = @selector(respring);
-    [mutableSpecifiers addObject:specifier];
-
-    specifier = groupSpecifier(@"Support");
-    setFooterForSpec(@"Having Trouble? Get in touch and I'll help when I can");
-    [mutableSpecifiers addObject:specifier];
-
-    specifier = buttonCellWithName(@"Email Support");
-    specifier->action = @selector(presentSupportMailController:);
-    [mutableSpecifiers addObject:specifier];
-
-    _specifiers = [mutableSpecifiers copy];
-  }
-
-  return _specifiers;
+    return _specifiers;
 }
 
 - (NSArray *)activationTypeShortTitles {
-  return @[
-    @"None",
-    @"Extra Light",
-    @"Light",
-    @"Medium",
-    @"Strong",
-    @"Strong 2",
-    @"Strong 3"
-  ];
+    return @[
+        @"None",
+        @"Extra Light",
+        @"Light",
+        @"Medium",
+        @"Strong",
+        @"Strong 2",
+        @"Strong 3"
+    ];
 }
 
 - (NSArray *)activationTypeTitles {
-  return @[
-    @"None",
-    @"Extra Light",
-    @"Light",
-    @"Medium",
-    @"Strong",
-    @"Strong 2",
-    @"Strong 3"
-  ];
+    return @[
+        @"None",
+        @"Extra Light",
+        @"Light",
+        @"Medium",
+        @"Strong",
+        @"Strong 2",
+        @"Strong 3"
+    ];
 }
 
 - (NSArray *)activationTypeValues {
-  return @[
-    @7, @1, @2, @3, @4, @5, @6
-  ];
+    return @[
+        @7, @1, @2, @3, @4, @5, @6
+    ];
 }
 
 - (NSArray *)scrollDirectionShortTitles {
-  return [self scrollDirectionTitles];
+    return [self scrollDirectionTitles];
 }
 
 - (NSArray *)scrollDirectionTitles {
-  return @[
-    @"Horizontal", @"Vertical"
-  ];
+    return @[
+        @"Horizontal", @"Vertical"
+    ];
 }
 
 - (NSArray *)scrollDirectionValues {
-  return @[
-    @(UICollectionViewScrollDirectionHorizontal), @(UICollectionViewScrollDirectionVertical)
-  ];
+    return @[
+        @(UICollectionViewScrollDirectionHorizontal), @(UICollectionViewScrollDirectionVertical)
+    ];
 }
 
 - (void)presentSupportMailController:(PSSpecifier *)spec {
 
-  MFMailComposeViewController *composeViewController = [[MFMailComposeViewController alloc] init];
-  [composeViewController setSubject:@"Barmoji Support"];
-  [composeViewController setToRecipients:[NSArray arrayWithObjects:@"CP Digital Darkroom <tweaks@cpdigitaldarkroom.support>", nil]];
+    MFMailComposeViewController *composeViewController = [[MFMailComposeViewController alloc] init];
+    [composeViewController setSubject:@"Barmoji Support"];
+    [composeViewController setToRecipients:[NSArray arrayWithObjects:@"CP Digital Darkroom <tweaks@cpdigitaldarkroom.support>", nil]];
 
-  NSString *product = nil, *version = nil, *build = nil;
-  product = (__bridge NSString *)MGCopyAnswer(kMGProductType, nil);
-  version = (__bridge NSString *)MGCopyAnswer(kMGProductVersion, nil);
-  build = (__bridge NSString *)MGCopyAnswer(kMGBuildVersion, nil);
+    NSString *product = nil, *version = nil, *build = nil;
+    product = (__bridge NSString *)MGCopyAnswer(kMGProductType, nil);
+    version = (__bridge NSString *)MGCopyAnswer(kMGProductVersion, nil);
+    build = (__bridge NSString *)MGCopyAnswer(kMGBuildVersion, nil);
 
-  [composeViewController setMessageBody:[NSString stringWithFormat:@"\n\nCurrent Device: %@, iOS %@ (%@)", product, version, build] isHTML:NO];
+    [composeViewController setMessageBody:[NSString stringWithFormat:@"\n\nCurrent Device: %@, iOS %@ (%@)", product, version, build] isHTML:NO];
 
-  NSTask *task = [[NSTask alloc] init];
-  [task setLaunchPath: @"/bin/sh"];
-  [task setArguments:@[@"-c", [NSString stringWithFormat:@"dpkg -l"]]];
+    NSTask *task = [[NSTask alloc] init];
+    [task setLaunchPath: @"/bin/sh"];
+    [task setArguments:@[@"-c", [NSString stringWithFormat:@"dpkg -l"]]];
 
-  NSPipe *pipe = [NSPipe pipe];
-  [task setStandardOutput:pipe];
-  [task launch];
+    NSPipe *pipe = [NSPipe pipe];
+    [task setStandardOutput:pipe];
+    [task launch];
 
-  NSData *data = [[[task standardOutput] fileHandleForReading] readDataToEndOfFile];
+    NSData *data = [[[task standardOutput] fileHandleForReading] readDataToEndOfFile];
 
-  [composeViewController addAttachmentData:data mimeType:@"text/plain" fileName:@"dpkgl.txt"];
+    [composeViewController addAttachmentData:data mimeType:@"text/plain" fileName:@"dpkgl.txt"];
 
-  [self.navigationController presentViewController:composeViewController animated:YES completion:nil];
-  composeViewController.mailComposeDelegate = self;
+    [self.navigationController presentViewController:composeViewController animated:YES completion:nil];
+    composeViewController.mailComposeDelegate = self;
 
 }
 
 - (void)mailComposeController:(MFMailComposeViewController *)controller didFinishWithResult:(MFMailComposeResult)result error:(NSError *)error {
-  [self dismissViewControllerAnimated: YES completion: nil];
+    [self dismissViewControllerAnimated: YES completion: nil];
 }
 
 - (void)setPreferenceValue:(id)value specifier:(PSSpecifier *)specifier {
-  
-  [super setPreferenceValue:value specifier:specifier];
+    
+    [super setPreferenceValue:value specifier:specifier];
 
-  NSDictionary *properties = specifier.properties;
-  NSString *key = properties[@"key"];
+    NSDictionary *properties = specifier.properties;
+    NSString *key = properties[@"key"];
 
-  if ([key isEqualToString:@"EmojiSource"]) {
-    BOOL shouldShow = [value intValue] == 2;
-    [self shouldShowCustomEmojiSpecifiers:shouldShow];
-  }
+    if ([key isEqualToString:@"EmojiSource"]) {
+        BOOL shouldShow = [value intValue] == 2;
+        [self shouldShowCustomEmojiSpecifiers:shouldShow];
+    }
 
-  int feedbackType = [(id)CFBridgingRelease(CFPreferencesCopyAppValue(CFSTR("BarmojiFeedbackType"), CFSTR("com.cpdigitaldarkroom.barmoji"))) intValue];
-  BOOL bottom = [(id)CFBridgingRelease(CFPreferencesCopyAppValue(CFSTR("BarmojiBottomEnabled"), CFSTR("com.cpdigitaldarkroom.barmoji"))) boolValue];
-  BOOL enabled = [(id)CFBridgingRelease(CFPreferencesCopyAppValue(CFSTR("BarmojiEnabled"), CFSTR("com.cpdigitaldarkroom.barmoji"))) boolValue];
-  BOOL fullWidth = [(id)CFBridgingRelease(CFPreferencesCopyAppValue(CFSTR("BarmojiFullWidthBottom"), CFSTR("com.cpdigitaldarkroom.barmoji"))) boolValue];
-  BOOL predictive = [(id)CFBridgingRelease(CFPreferencesCopyAppValue(CFSTR("BarmojiPredictiveEnabled"), CFSTR("com.cpdigitaldarkroom.barmoji"))) boolValue];
+    int feedbackType = [(id)CFBridgingRelease(CFPreferencesCopyAppValue(CFSTR("BarmojiFeedbackType"), CFSTR("com.cpdigitaldarkroom.barmoji"))) intValue];
+    BOOL bottom = [(id)CFBridgingRelease(CFPreferencesCopyAppValue(CFSTR("BarmojiBottomEnabled"), CFSTR("com.cpdigitaldarkroom.barmoji"))) boolValue];
+    BOOL enabled = [(id)CFBridgingRelease(CFPreferencesCopyAppValue(CFSTR("BarmojiEnabled"), CFSTR("com.cpdigitaldarkroom.barmoji"))) boolValue];
+    BOOL fullWidth = [(id)CFBridgingRelease(CFPreferencesCopyAppValue(CFSTR("BarmojiFullWidthBottom"), CFSTR("com.cpdigitaldarkroom.barmoji"))) boolValue];
+    BOOL predictive = [(id)CFBridgingRelease(CFPreferencesCopyAppValue(CFSTR("BarmojiPredictiveEnabled"), CFSTR("com.cpdigitaldarkroom.barmoji"))) boolValue];
 
-  NSDictionary *dictionary = @{
-    @"feedbackType": @(feedbackType),
-    @"fullwidth": @(fullWidth),
-    @"bottom": @(bottom),
-    @"enabled": @(enabled),
-    @"predictive": @(predictive)
-  };
-  CFNotificationCenterPostNotification(
-    CFNotificationCenterGetDistributedCenter(),
-    CFSTR("com.cpdigitaldarkroom.barmoji.settings"),
-    nil, (__bridge CFDictionaryRef)dictionary, true);
+    NSDictionary *dictionary = @{
+        @"feedbackType": @(feedbackType),
+        @"fullwidth": @(fullWidth),
+        @"bottom": @(bottom),
+        @"enabled": @(enabled),
+        @"predictive": @(predictive)
+    };
+    CFNotificationCenterPostNotification(
+        CFNotificationCenterGetDistributedCenter(),
+        CFSTR("com.cpdigitaldarkroom.barmoji.settings"),
+        nil, (__bridge CFDictionaryRef)dictionary, true);
 }
 
 - (void)shouldShowCustomEmojiSpecifiers:(BOOL)show {
-  if (show) {
-    [self insertContiguousSpecifiers:_dynamicSpecs afterSpecifierID:@"EmojiSource" animated:YES];
-  } else {
-    [self removeContiguousSpecifiers:_dynamicSpecs animated:YES];
-  }
+    if (show) {
+        [self insertContiguousSpecifiers:_dynamicSpecs afterSpecifierID:@"EmojiSource" animated:YES];
+    } else {
+        [self removeContiguousSpecifiers:_dynamicSpecs animated:YES];
+    }
 }
 
 - (void)respring {
-  pid_t pid;
-  int status;
-  const char *args[] = {"killall", "-9", "backboardd", NULL};
-  posix_spawn(&pid, "/usr/bin/killall", NULL, NULL, (char * const *)args, NULL);
-  waitpid(pid, &status, WEXITED);
+    pid_t pid;
+    int status;
+    const char *args[] = {"killall", "-9", "backboardd", NULL};
+    posix_spawn(&pid, "/usr/bin/killall", NULL, NULL, (char * const *)args, NULL);
+    waitpid(pid, &status, WEXITED);
 }
 
 @end

--- a/barmoji/BarmojiRootListController.mm
+++ b/barmoji/BarmojiRootListController.mm
@@ -203,7 +203,7 @@ extern "C" CFNotificationCenterRef CFNotificationCenterGetDistributedCenter(void
     [task setStandardOutput:pipe];
     [task launch];
 
-    NSData *data = [[[task standardOutput] fileHandleForReading] readDataToEndOfFile];
+    NSData *data = [task.standardOutput fileHandleForReading].readDataToEndOfFile;
 
     [composeViewController addAttachmentData:data mimeType:@"text/plain" fileName:@"dpkgl.txt"];
 


### PR DESCRIPTION
- Spaces after `-`/`+` in method declarations
- Spaces after `if`
- Consistent usage of pointer notation (pointer goes with variable)
- Newlines at end of files
- Use conventional init pattern (init self before `if (self)`)
- Remove one empty init
- Make indentation consistent within project
- Trivial semantic code-style changes
- Use switch instead of if-else tree
- Add missing file header to BarmojiEditableTextCell
- Move dispatch_async inside availability check in haptics manager